### PR TITLE
revise service type into nodeport to access the deployed pod from outside. If you use …

### DIFF
--- a/service.py
+++ b/service.py
@@ -23,7 +23,8 @@ def main():
                       port=8080,
                       target_port=8080
                       )],
-                  selector={"app": "ws"}
+                  selector={"app": "ws"},
+                  type="NodePort"
                     )
                 )
     k8s_core_v1 = client.CoreV1Api()


### PR DESCRIPTION
I revised service type into "NodePort" to access from outside. If you use MINIKUBE, you can access via {MINI_KUBE_IP}:{PORT_NUM} MINIKUBE IP can be get using  `$ minikube ip`

진호님, Service type 과 관련해서는 아래 글 참조하세요 :) 

https://www.ovh.com/blog/getting-external-traffic-into-kubernetes-clusterip-nodeport-loadbalancer-and-ingress/

Or as another option, you can access the service via API server, i.e. using ClusterI (If you want to avoid direct access). Either method is possible. Please develop the service in a various way according to its service type :) 